### PR TITLE
v4.23.0.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-channels:
-    build: or-tools
-aggregate_check: false

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+channels:
+    build: or-tools
+aggregate_check: false

--- a/recipe/_run_test.py
+++ b/recipe/_run_test.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from google.protobuf.struct_pb2 import ListValue, Struct
+
+print("Tests complete")

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,15 +12,15 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: true  #[py<36]
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
   run:
-    - python >=3.6
+    - python
     - types-futures
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,8 +24,12 @@ requirements:
     - types-futures
 
 test:
+  requires:
+    - pip
   commands:
-    - test -f $SP_DIR/google-stubs/protobuf/__init__.pyi
+    - test -f $SP_DIR/google-stubs/protobuf/__init__.pyi  # [not win]
+    - if not exist %SP_DIR%\\google-stubs\\protobuf\\__init__.pyi exit 1 # [win]
+    - pip check
 
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,9 +30,16 @@ test:
 
 about:
   home: https://github.com/python/typeshed
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://typing.readthedocs.io/
   summary: Typing stubs for protobuf
+  description: |
+    This is a PEP 561 type stub package for the protobuf package. 
+    It can be used by type-checking tools like mypy, pyright, 
+    pytype, PyCharm, etc. to check code that uses protobuf.
   license: Apache-2.0 AND MIT
   license_file: LICENSE
+  licence_family: Apache
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,8 @@ requirements:
   host:
     - pip
     - python
+    - setuptools
+    - wheel
   run:
     - python
     - types-futures
@@ -43,7 +45,7 @@ about:
     pytype, PyCharm, etc. to check code that uses protobuf.
   license: Apache-2.0 AND MIT
   license_file: LICENSE
-  licence_family: Apache
+  license_family: Apache
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "types-protobuf" %}
-{% set version = "4.21.0.5" %}
+{% set version = "4.23.0.1" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/types-protobuf-{{ version }}.tar.gz
-  sha256: 819a7c67e69476e39c3f0c9871bbb9ee82313645d317b6daeb60ac95a309dbd3
+  sha256: 7bd5ea122a057b11a82b785d9de464932a1e9175fe977a4128adef11d7f35547
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,8 +26,11 @@ requirements:
     - types-futures
 
 test:
+  files:
+    - _run_test.py
   requires:
     - pip
+    - protobuf
   commands:
     - test -f $SP_DIR/google-stubs/protobuf/__init__.pyi  # [not win]
     - if not exist %SP_DIR%\\google-stubs\\protobuf\\__init__.pyi exit 1 # [win]

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,0 +1,2 @@
+# HACK: from __future__ import annotations must be the first line, but conda build injects print statements. 
+import _run_test


### PR DESCRIPTION
`or-tools` ❄️  -> `mypy-protobuf` -> `types-protobuf`

# types-protobuf v4.23.01

## Notes
- This is a new feedstock
- This package doesn't generate any imports by itself, It produces a partial stub. To test, protobuf is installed and a simple import test is ran to make sure the additional stubs are accessible. 